### PR TITLE
Updated the code to work for multiple carousels in a single page

### DIFF
--- a/src/app/modules/ngx-carousel-3d/ngx-carousel-3d.component.html
+++ b/src/app/modules/ngx-carousel-3d/ngx-carousel-3d.component.html
@@ -4,7 +4,7 @@
       <div class="carousel-3d-loader-percentage">{{ percentLoaded }}</div>
   </div>
   <div  [hidden]="isLoading" [ngSwitch]="isSuccessful" >
-      <div #carousel3D class="carousel-3d" [hidden]="!isRendered && !isSuccessful">
+      <div #carousel3D [ngClass]="[slideClass,'carousel-3d']" [hidden]="!isRendered && !isSuccessful">
           <ng-content></ng-content>
       </div>
       <p  [hidden]="isSuccessful"  class="carousel-3d-loader-error">There was a problem during load</p>

--- a/src/app/modules/ngx-carousel-3d/ngx-carousel-3d.component.ts
+++ b/src/app/modules/ngx-carousel-3d/ngx-carousel-3d.component.ts
@@ -80,7 +80,11 @@ export class NgxCarousel3dComponent implements OnInit, OnDestroy, OnChanges {
 
 
 
-                    this.$wrapper = jquery('div.'+this.slideClass);
+                    if(this.slideClass){
+                    this.$wrapper = jquery('div.'+this.slideClass);                    
+                    }else{
+                    this.$wrapper = jquery('div.carousel-3d');
+                    }
                     this.$wrapper.css({'width': outerWidth + 'px', 'height': outerHeight + 'px'});
                     this.$slides = this.$wrapper.children().toArray();
 

--- a/src/app/modules/ngx-carousel-3d/ngx-carousel-3d.component.ts
+++ b/src/app/modules/ngx-carousel-3d/ngx-carousel-3d.component.ts
@@ -25,6 +25,7 @@ export class NgxCarousel3dComponent implements OnInit, OnDestroy, OnChanges {
     @Input() onLastSlide: Function;
     @Input() onSlideChange: Function;
     @Input() onSelectedClick: Function;
+    @Input() slideClass:string;
 
 
     public isLoading = true;
@@ -79,7 +80,7 @@ export class NgxCarousel3dComponent implements OnInit, OnDestroy, OnChanges {
 
 
 
-                    this.$wrapper = jquery('div.carousel-3d');
+                    this.$wrapper = jquery('div.'+this.slideClass);
                     this.$wrapper.css({'width': outerWidth + 'px', 'height': outerHeight + 'px'});
                     this.$slides = this.$wrapper.children().toArray();
 


### PR DESCRIPTION
in ngx-carousel-3d.component.ts  file when takings the $Slides array using jquery it is getting all the elements in a single page the class name 'carousel-3d'. so if we have multiple carousels in a single page then this $slides array will get elements from other carousel also. I have included a slideClass variable where whenever we are using a <ngx-carousel-3d> tag we have to pass this class with slides and options like below.

              <ngx-carousel-3d [slides]="slides" [slideClass]="slideClass" [options]="options"  #carousel>

if we dont pass this class. still the code works but only for one carousel.